### PR TITLE
PEP and verbosity issues in calc_circumcenters...

### DIFF
--- a/scipy/spatial/spherical_voronoi.py
+++ b/scipy/spatial/spherical_voronoi.py
@@ -5,7 +5,8 @@ Spherical Voronoi Code
 
 """
 #
-# Copyright (C)  Tyler Reddy, Ross Hemsley, Edd Edmondson, Nikolai Nowaczyk, Joe Pitt-Francis, 2015.
+# Copyright (C)  Tyler Reddy, Ross Hemsley, Edd Edmondson,
+#                Nikolai Nowaczyk, Joe Pitt-Francis, 2015.
 #
 # Distributed under the same BSD license as Scipy.
 #

--- a/scipy/spatial/spherical_voronoi.py
+++ b/scipy/spatial/spherical_voronoi.py
@@ -19,14 +19,20 @@ __all__ = ['SphericalVoronoi']
 
 
 def calc_circumcenter_circumsphere_tetrahedron_vectorized(tetrahedron_coord_array):
-    """ Get the cirumcenters of the circumspheres of tetrahedrons.
+    """ Calculates the cirumcenters of the circumspheres of tetrahedrons.
 
-    An alternative implementation based on
+    An implementation based on
     http://mathworld.wolfram.com/Circumsphere.html
-    because of issues with the initial implementation from the Berkeley page.
 
-    Vectorized version for use with multiple tetrahedra in
-    tetrahedron_coord_array -- the latter should have shape (N, 4, 3).'''
+    Parameters
+    ----------
+    tetrahedrons : an array of shape (N, 4, 3)
+        consisting of N tetrahedrons defined by 4 points in 3D
+
+    Returns
+    ----------
+    circumcenters : an array of shape (N, 3)
+        consisting of the N circumcenters of the tetrahedrons in 3D
 
     """
 

--- a/scipy/spatial/spherical_voronoi.py
+++ b/scipy/spatial/spherical_voronoi.py
@@ -12,6 +12,7 @@ Spherical Voronoi Code
 #
 
 import numpy as np
+import numpy.matlib
 import scipy
 import math
 
@@ -49,6 +50,7 @@ def calc_circumcenters(tetrahedrons):
     nominator = np.vstack((dx, dy, dz))
     denominator = np.matlib.repmat(2 * np.linalg.det(a), 3, 1)
     return (nominator / denominator).transpose()
+
 
 def convert_cartesian_array_to_spherical_array(coord_array,angle_measure='radians'):
     '''Take shape (N,3) cartesian coord_array and return an array of the same shape in spherical polar form (r, theta, phi). Based on StackOverflow response: http://stackoverflow.com/a/4116899

--- a/scipy/spatial/spherical_voronoi.py
+++ b/scipy/spatial/spherical_voronoi.py
@@ -18,7 +18,7 @@ import math
 __all__ = ['SphericalVoronoi']
 
 
-def calc_circumcenter_circumsphere_tetrahedron_vectorized(tetrahedrons):
+def calc_circumcenters(tetrahedrons):
     """ Calculates the cirumcenters of the circumspheres of tetrahedrons.
 
     An implementation based on
@@ -356,7 +356,7 @@ class SphericalVoronoi:
         simplex_coords = tri.points[tri.simplices] #triangles on sphere surface
         simplex_coords = np.insert(simplex_coords, 3, np.zeros((1,3)), axis = 1)
         #step 3: produce circumspheres / circumcenters of tetrahedra from 3D Delaunay
-        array_circumcenter_coords = calc_circumcenter_circumsphere_tetrahedron_vectorized(simplex_coords)
+        array_circumcenter_coords = calc_circumcenters(simplex_coords)
         #step 4: project tetrahedron circumcenters up to the surface of the sphere, to produce the Voronoi vertices
         array_vector_lengths = scipy.spatial.distance.cdist(array_circumcenter_coords, np.zeros((1,3)))
         array_Voronoi_vertices = (self.estimated_sphere_radius / np.abs(array_vector_lengths)) * array_circumcenter_coords

--- a/scipy/spatial/tests/test_spherical_voronoi.py
+++ b/scipy/spatial/tests/test_spherical_voronoi.py
@@ -1,11 +1,37 @@
 import numpy as np
 from numpy.testing import (verbose, TestCase, run_module_suite, assert_,
         assert_raises, assert_array_equal, assert_equal, assert_almost_equal,
-        assert_allclose)
+        assert_allclose, assert_array_almost_equal)
 from numpy.testing.decorators import skipif
 import math
 from scipy.spatial.spherical_voronoi import SphericalVoronoi
 from scipy.spatial import spherical_voronoi
+
+
+class TestCircumcenters(TestCase):
+
+    def test_circumcenters(self):
+
+        tetrahedrons = np.array([
+            [[1, 2, 3],
+            [-1.1, -2.1, -3.1],
+            [-1.2, 2.2, 3.2],
+            [-1.3, -2.3, 3.3]],
+            [[10, 20, 30],
+            [-10.1, -20.1, -30.1],
+            [-10.2, 20.2, 30.2],
+            [-10.3, -20.3, 30.3]]
+        ])
+
+        result = spherical_voronoi.calc_circumcenters(tetrahedrons)
+
+        expected = [
+            [-0.5680861153262529, -0.133279590288315, 0.1843323216995444],
+            [-0.5965330784014926, -0.1480377040397778, 0.1981967854886021]
+        ]
+
+        assert_array_almost_equal(result, expected)
+
 
 class Test_delaunay_triangulation_on_sphere_surface(TestCase):
 


### PR DESCRIPTION
This PR addresses the PEP and verbosity issues we discussed for the function `calc_circumcenter_circumsphere_tetrahedron_vectorized`. It is renamed to `calc_circumcenters`. I also added an elementary unittest.
