### PR TITLE
TST: add openblas_support.py

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -15,6 +15,8 @@ trigger:
 
 # the version of OpenBLAS used is currently 0.3.7
 # and should be updated to match scipy-wheels as appropriate
+variables:
+    openblas_version: 0.3.7
 
 jobs:
 - job: Linux_Python_36_32bit_full
@@ -34,11 +36,12 @@ jobs:
            apt-get -y install gfortran-5 wget && \
            cd .. && \
            mkdir openblas && cd openblas && \
-           wget https://3f23b170c54c2533c070-1c8a9b3114517dc5fe17b7c3f8c63a43.ssl.cf2.rackcdn.com/openblas-v0.3.7-manylinux1_i686.tar.gz && \
-           tar zxvf openblas-v0.3.7-manylinux1_i686.tar.gz && \
-           cp -r ./usr/local/lib/* /usr/lib && \
-           cp ./usr/local/include/* /usr/include && \
+           target=$(python3.6 ../scipy/tools/openblas_support.py) && \
+           cp -r $target/lib/* /usr/lib && \
+           cp $target/include/* /usr/include && \
            cd ../scipy && \
+           F77=gfortran-5 F90=gfortran-5 python3.6 setup.py install && \
+           python3.6 tools/openblas_support.py --check_version $(openblas_version) && \
            F77=gfortran-5 F90=gfortran-5 python3.6 runtests.py --mode=full -- -n auto -s --junitxml=junit/test-results.xml --cov-config=.coveragerc --cov-report=xml --cov-report=html"
     displayName: 'Run 32-bit Ubuntu Docker Build / Tests'
   - task: PublishTestResults@2
@@ -56,9 +59,6 @@ jobs:
   condition: and(succeeded(), ne(variables['Build.SourceBranch'], 'refs/heads/master'))  # skip for PR merges
   pool:
     vmImage: 'VS2017-Win2016'
-  variables:
-      OPENBLAS_32: https://3f23b170c54c2533c070-1c8a9b3114517dc5fe17b7c3f8c63a43.ssl.cf2.rackcdn.com/openblas-v0.3.7-win32-gcc_7_1_0.zip
-      OPENBLAS_64: https://3f23b170c54c2533c070-1c8a9b3114517dc5fe17b7c3f8c63a43.ssl.cf2.rackcdn.com/openblas-v0.3.7-win_amd64-gcc_7_1_0.zip
   strategy:
     maxParallel: 4
     matrix:
@@ -95,15 +95,12 @@ jobs:
   - script: python -m pip install --upgrade pip setuptools wheel
     displayName: 'Install tools'
   - powershell: |
-      $wc = New-Object net.webclient;
-      $wc.Downloadfile("$(OPENBLAS)", "openblas.zip")
-      $tmpdir = New-TemporaryFile | %{ rm $_; mkdir $_ }
-      Expand-Archive "openblas.zip" $tmpdir
-      $pyversion = python -c "from __future__ import print_function; import sys; print(sys.version.split()[0])"
+      $pyversion = python -c "import sys; print(sys.version.split()[0])"
       Write-Host "Python Version: $pyversion"
       $target = "C:\\hostedtoolcache\\windows\\Python\\$pyversion\\$(PYTHON_ARCH)\\lib\\openblas.a"
       Write-Host "target path: $target"
-      cp $tmpdir\$(BITS)\lib\libopenblas_v0.3.7-gcc_7_1_0.a $target
+      $openblas = python tools/openblas_support.py
+      cp $openblas $target
     displayName: 'Download / Install OpenBLAS'
   - powershell: |
       # wheels appear to use mingw64 version 6.3.0, but 6.4.0
@@ -160,6 +157,9 @@ jobs:
           pip install $_.FullName
       }
     displayName: 'Build SciPy'
+  - powershell: |
+      python tools/openblas_support.py --check_version $(openblas_version)
+    displayName: 'Check version of OpenBLAS linked to SciPy'
   - powershell: |
       $env:PATH = "C:\\ProgramData\\chocolatey\\lib\\mingw\\tools\\install\\mingw$(BITS)\\bin;" + $env:PATH
       python runtests.py -n --mode=$(TEST_MODE) -- -n auto -rsx --junitxml=junit/test-results.xml --cov=scipy --cov-report=xml --cov-report=html

--- a/tools/openblas_support.py
+++ b/tools/openblas_support.py
@@ -1,0 +1,281 @@
+import os
+import sys
+import glob
+import shutil
+import textwrap
+import platform
+
+from tempfile import mkstemp, gettempdir
+from urllib.request import urlopen, Request
+from urllib.error import HTTPError
+import zipfile
+import tarfile
+
+OPENBLAS_V = 'v0.3.8'
+OPENBLAS_LONG = 'v0.3.5-605-gc815b8fb'  # the 0.3.5 is misleading
+BASE_LOC = ''
+ANACONDA = 'https://anaconda.org/multibuild-wheels-staging/openblas-libs'
+ARCHITECTURES = ['', 'windows', 'darwin', 'aarch64', 'x86', 'ppc64le', 's390x']
+
+IS_32BIT = sys.maxsize < 2**32
+def get_arch():
+    if platform.system() == 'Windows':
+        ret = 'windows'
+    elif platform.system() == 'Darwin':
+        ret = 'darwin'
+    else:
+        ret = platform.uname().machine
+        # What do 32 bit machines report?
+        # If they are a docker, they report x86_64 or i686
+        if 'x86' in ret or ret == 'i686':
+            ret = 'x86'
+    assert ret in ARCHITECTURES
+    return ret
+
+def get_ilp64():
+    if os.environ.get("NPY_USE_BLAS_ILP64", "0") == "0":
+        return None
+    if IS_32BIT:
+        raise RuntimeError("NPY_USE_BLAS_ILP64 set on 32-bit arch")
+    return "64_"
+
+def download_openblas(target, arch, ilp64):
+    fnsuffix = {None: "", "64_": "64_"}[ilp64]
+    filename = ''
+    if arch in ('aarch64', 'ppc64le', 's390x'):
+        suffix = f'manylinux2014_{arch}.tar.gz'
+        filename = f'{ANACONDA}/{OPENBLAS_LONG}/download/openblas{fnsuffix}-{OPENBLAS_LONG}-{suffix}'
+        typ = 'tar.gz'
+        typ = 'tar.gz'
+    elif arch == 'darwin':
+        suffix = 'macosx_10_9_x86_64-gf_1becaaa.tar.gz'
+        filename = f'{ANACONDA}/{OPENBLAS_LONG}/download/openblas{fnsuffix}-{OPENBLAS_LONG}-{suffix}'
+        typ = 'tar.gz'
+    elif arch == 'windows':
+        if IS_32BIT:
+            suffix = 'win32-gcc_7_1_0.zip'
+        else:
+            suffix = 'win_amd64-gcc_7_1_0.zip'
+        filename = f'{ANACONDA}/{OPENBLAS_LONG}/download/openblas{fnsuffix}-{OPENBLAS_LONG}-{suffix}'
+        typ = 'zip'
+    elif 'x86' in arch:
+        if IS_32BIT:
+            suffix = 'manylinux1_i686.tar.gz'
+        else:
+            suffix = 'manylinux1_x86_64.tar.gz'
+        filename = f'{ANACONDA}/{OPENBLAS_LONG}/download/openblas{fnsuffix}-{OPENBLAS_LONG}-{suffix}'
+        typ = 'tar.gz'
+    if not filename:
+        return None
+    print("Downloading:", filename, file=sys.stderr)
+    try:
+        with open(target, 'wb') as fid:
+            # anaconda.org download location guards against
+            # scraping so trick it with a fake browser header
+            # see: https://medium.com/@speedforcerun/python-crawler-http-error-403-forbidden-1623ae9ba0f
+            headers = {'User-Agent': 'Mozilla/5.0 (Windows NT 6.1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/41.0.2228.0 Safari/537.3'}
+            req = Request(url=filename, headers=headers)
+            fid.write(urlopen(req).read())
+    except HTTPError as e:
+        print(f'Could not download "{filename}"')
+        print(f'Error message: {e}')
+        return None
+    return typ
+
+def setup_openblas(arch=get_arch(), ilp64=get_ilp64()):
+    '''
+    Download and setup an openblas library for building. If successful,
+    the configuration script will find it automatically.
+
+    Returns
+    -------
+    msg : str
+        path to extracted files on success, otherwise indicates what went wrong
+        To determine success, do ``os.path.exists(msg)``
+    '''
+    _, tmp = mkstemp()
+    if not arch:
+        raise ValueError('unknown architecture')
+    typ = download_openblas(tmp, arch, ilp64)
+    if not typ:
+        return ''
+    if arch == 'windows':
+        if not typ == 'zip':
+            return 'expecting to download zipfile on windows, not %s' % str(typ)
+        return unpack_windows_zip(tmp)
+    else:
+        if not typ == 'tar.gz':
+            return 'expecting to download tar.gz, not %s' % str(typ)
+        return unpack_targz(tmp)
+
+def unpack_windows_zip(fname):
+    with zipfile.ZipFile(fname, 'r') as zf:
+        # Get the openblas.a file, but not openblas.dll.a nor openblas.dev.a
+        lib = [x for x in zf.namelist() if OPENBLAS_LONG in x and
+                  x.endswith('a') and not x.endswith('dll.a') and
+                  not x.endswith('dev.a')]
+        if not lib:
+            return 'could not find libopenblas_%s*.a ' \
+                    'in downloaded zipfile' % OPENBLAS_LONG
+        target = os.path.join(gettempdir(), 'openblas.a')
+        with open(target, 'wb') as fid:
+            fid.write(zf.read(lib[0]))
+    return target
+
+def unpack_targz(fname):
+    target = os.path.join(gettempdir(), 'openblas')
+    if not os.path.exists(target):
+        os.mkdir(target)
+    with tarfile.open(fname, 'r') as zf:
+        # Strip common prefix from paths when unpacking
+        prefix = os.path.commonpath(zf.getnames())
+        extract_tarfile_to(zf, target, prefix)
+        return target
+
+def extract_tarfile_to(tarfileobj, target_path, archive_path):
+    """Extract TarFile contents under archive_path/ to target_path/"""
+
+    target_path = os.path.abspath(target_path)
+
+    def get_members():
+        for member in tarfileobj.getmembers():
+            if archive_path:
+                norm_path = os.path.normpath(member.name)
+                if norm_path.startswith(archive_path + os.path.sep):
+                    member.name = norm_path[len(archive_path)+1:]
+                else:
+                    continue
+
+            dst_path = os.path.abspath(os.path.join(target_path, member.name))
+            if os.path.commonpath([target_path, dst_path]) != target_path:
+                # Path not under target_path, probably contains ../
+                continue
+
+            yield member
+
+    tarfileobj.extractall(target_path, members=get_members())
+
+def make_init(dirname):
+    '''
+    Create a _distributor_init.py file for OpenBlas
+    '''
+    with open(os.path.join(dirname, '_distributor_init.py'), 'wt') as fid:
+        fid.write(textwrap.dedent("""
+            '''
+            Helper to preload windows dlls to prevent dll not found errors.
+            Once a DLL is preloaded, its namespace is made available to any
+            subsequent DLL. This file originated in the numpy-wheels repo,
+            and is created as part of the scripts that build the wheel.
+            '''
+            import os
+            from ctypes import WinDLL
+            import glob
+            if os.name == 'nt':
+                # convention for storing / loading the DLL from
+                # numpy/.libs/, if present
+                try:
+                    basedir = os.path.dirname(__file__)
+                except:
+                    pass
+                else:
+                    libs_dir = os.path.abspath(os.path.join(basedir, '.libs'))
+                    DLL_filenames = []
+                    if os.path.isdir(libs_dir):
+                        for filename in glob.glob(os.path.join(libs_dir,
+                                                             '*openblas*dll')):
+                            # NOTE: would it change behavior to load ALL
+                            # DLLs at this path vs. the name restriction?
+                            WinDLL(os.path.abspath(filename))
+                            DLL_filenames.append(filename)
+                if len(DLL_filenames) > 1:
+                    import warnings
+                    warnings.warn("loaded more than 1 DLL from .libs:\\n%s" %
+                              "\\n".join(DLL_filenames),
+                              stacklevel=1)
+    """))
+
+def test_setup(arches):
+    '''
+    Make sure all the downloadable files exist and can be opened
+    '''
+    def items():
+        for arch in arches:
+            yield arch, None
+            if arch in ('x86', 'darwin', 'windows'):
+                yield arch, '64_'
+
+    for arch, ilp64 in items():
+        if arch == '':
+            continue
+
+        target = None
+        try:
+            try:
+                target = setup_openblas(arch, ilp64)
+            except:
+                print(f'Could not setup {arch}')
+                raise
+            if not target:
+                raise RuntimeError(f'Could not setup {arch}')
+            print(target)
+            if arch == 'windows':
+                if not target.endswith('.a'):
+                    raise RuntimeError("Not .a extracted!")
+            else:
+                files = glob.glob(os.path.join(target, "lib", "*.a"))
+                if not files:
+                    raise RuntimeError("No lib/*.a unpacked!")
+        finally:
+            if target is not None:
+                if os.path.isfile(target):
+                    os.unlink(target)
+                else:
+                    shutil.rmtree(target)
+
+def test_version(expected_version, ilp64=get_ilp64()):
+    """
+    Assert that expected OpenBLAS version is
+    actually available via SciPy
+    """
+    import scipy
+    import scipy.linalg
+    import ctypes
+
+    dll = ctypes.CDLL(scipy.linalg.cython_blas.__file__)
+    if ilp64 == "64_":
+        get_config = dll.openblas_get_config64_
+    else:
+        get_config = dll.openblas_get_config
+    get_config.restype=ctypes.c_char_p
+    res = get_config()
+    print('OpenBLAS get_config returned', str(res))
+    check_str = b'OpenBLAS %s' % expected_version[0].encode()
+    assert check_str in res
+
+    if 'dev' not in expected_version[0]:
+        assert b'dev' not in res
+
+    if ilp64:
+        assert b"USE64BITINT" in res
+    else:
+        assert b"USE64BITINT" not in res
+
+if __name__ == '__main__':
+    import argparse
+    parser = argparse.ArgumentParser(
+        description='Download and expand an OpenBLAS archive for this ' \
+                    'architecture')
+    parser.add_argument('--test', nargs='*', default=None,
+        help='Test different architectures. "all", or any of %s' % ARCHITECTURES)
+    parser.add_argument('--check_version', nargs=1, default=None,
+        help='Check provided OpenBLAS version string against available OpenBLAS')
+    args = parser.parse_args()
+    if args.check_version is not None:
+        test_version(args.check_version)
+    elif args.test is None:
+        print(setup_openblas())
+    else:
+        if len(args.test) == 0 or 'all' in args.test:
+            test_setup(ARCHITECTURES)
+        else:
+            test_setup(args.test)


### PR DESCRIPTION
* borrow/adjust openblas_support.py used
in the NumPy project as a common handling
point for OpenBLAS-related version checking
& downloads

* adjust test_version() function to use scipy.linalg
instead of NumPy for checking the linked in OpenBLAS
version; also, increase the sensitivity of this function
so it can distinguish between development & stable
releases of OpenBLAS

* openblas_support.py now uses anaconda.org instead
of rackspace, as the NumFOCUS ecosystem is migrating
off the latter

* adjust azure pipelines configuration to leverage
openblas_support.py to retrieve OpenBLAS & verify
version linked to SciPy