### PR TITLE
CI, MAINT: use built-in Azure container

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -28,26 +28,28 @@ jobs:
   condition: and(succeeded(), ne(variables['Build.SourceBranch'], 'refs/heads/master'))  # skip for PR merges
   pool:
     vmImage: 'ubuntu-16.04'
+  container:
+    image: i386/ubuntu:xenial
   steps:
   - script: |
-           docker pull i386/ubuntu:bionic
-           docker run -v $(pwd):/scipy i386/ubuntu:bionic /bin/bash -c "cd scipy && \
-           apt-get -y update && \
-           apt-get -y install curl python3.6-dev python3.6 python3-distutils pkg-config libpng-dev libjpeg8-dev libfreetype6-dev && \
-           curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py && \
-           python3.6 get-pip.py && \
-           pip3 --version && \
-           pip3 install setuptools wheel numpy==1.14.5 cython==0.29.18 pybind11 pytest pytest-timeout pytest-xdist pytest-env pytest-cov Pillow mpmath matplotlib==3.1.3 --user && \
-           apt-get -y install gfortran-5 wget && \
-           cd .. && \
-           mkdir openblas && cd openblas && \
-           target=\$(python3.6 ../scipy/tools/openblas_support.py) && \
-           cp -r \$target/lib/* /usr/lib && \
-           cp \$target/include/* /usr/include && \
-           cd ../scipy && \
-           F77=gfortran-5 F90=gfortran-5 python3.6 setup.py install && \
-           python3.6 tools/openblas_support.py --check_version $(openblas_version) && \
-           F77=gfortran-5 F90=gfortran-5 python3.6 runtests.py --mode=full -- -n auto -s --junitxml=junit/test-results.xml --cov-config=.coveragerc --cov-report=xml --cov-report=html"
+           cd scipy
+           ls -tlrh
+           apt-get -y update
+           apt-get -y install curl python3.6-dev python3.6 python3-distutils pkg-config libpng-dev libjpeg8-dev libfreetype6-dev
+           curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
+           python3.6 get-pip.py
+           pip3 --version 
+           pip3 install setuptools wheel numpy==1.14.5 cython==0.29.18 pybind11 pytest pytest-timeout pytest-xdist pytest-env pytest-cov Pillow mpmath matplotlib==3.1.3 --user 
+           apt-get -y install gfortran-5 wget 
+           cd .. 
+           mkdir openblas && cd openblas 
+           target=\$(python3.6 ../scipy/tools/openblas_support.py) 
+           cp -r \$target/lib/* /usr/lib 
+           cp \$target/include/* /usr/include 
+           cd ../scipy 
+           F77=gfortran-5 F90=gfortran-5 python3.6 setup.py install
+           python3.6 tools/openblas_support.py --check_version $(openblas_version)
+           F77=gfortran-5 F90=gfortran-5 python3.6 runtests.py --mode=full -- -n auto -s --junitxml=junit/test-results.xml --cov-config=.coveragerc --cov-report=xml --cov-report=html
     displayName: 'Run 32-bit Ubuntu Docker Build / Tests'
   - task: PublishTestResults@2
     condition: succeededOrFailed()


### PR DESCRIPTION
* use the built-in Azure container feature:
https://docs.microsoft.com/en-us/azure/devops/pipelines/process/container-phases?view=azure-devops#single-job

* avoids current ugly approach of having the entire
docker run operation/commands squashes into a single
string fed to `docker run`, allows us to split build/test/other
steps in the run/GUI eventually, and may also benefit
from other container-related features moving forward