### PR TITLE
MAINT: GHA MacOS setup.py update

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -90,4 +90,7 @@ jobs:
     - name: Test SciPy
       run: |
         export LIBRARY_PATH="$LIBRARY_PATH:/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/lib"
-        SCIPY_USE_PYTHRAN=`test ${{ matrix.python-version }} != 3.9; echo $?` python -u runtests.py -- --durations=10 --timeout=60
+        export SCIPY_USE_PYTHRAN=1
+        python setup.py install
+        cd /tmp
+        python -m pytest --pyargs scipy --durations=10 --timeout=60

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -92,4 +92,4 @@ jobs:
         export SCIPY_USE_PYTHRAN=1
         python setup.py install
         cd /tmp
-        python -m pytest --pyargs scipy --durations=10 --timeout=60 -n 3
+        python -m pytest --pyargs scipy --durations=10 --timeout=80 -n 3

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -20,7 +20,6 @@ concurrency:
 jobs:
   test_macos:
     name: macOS Test Matrix
-    if: "github.repository == 'scipy/scipy' || github.repository == ''"
     runs-on: macos-latest
     strategy:
       max-parallel: 3

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -92,4 +92,4 @@ jobs:
         export SCIPY_USE_PYTHRAN=1
         python setup.py install
         cd /tmp
-        python -m pytest --pyargs scipy --durations=10 --timeout=60
+        python -m pytest --pyargs scipy --durations=10 --timeout=60 -n 3


### PR DESCRIPTION
* the `setup.py` MacOS Python `3.8` CI job is starting to fail with timeouts for multiprocessing `Pool`-related code in recent PRs like gh-17777 and gh-17829

* nothing stands out in the build logs when I do a side-by-side diff, and the GHA job history seems to suggest the failure doesn't happen every time the CI is flushed, but perhaps more often lately

* make a few cleanups here in attempt to fix

* first off, we can simplify the Pythran config--there's only one job left in this file after the splitting with `meson`, and it is Python `3.8` (`3.8` support may be on the way out too, but I'm assuming we delay that a tiny bit more perhaps)

* previous discussions like https://github.com/scipy/scipy/issues/11835 with MacOS Python 3.8 multiprocessing Pool hangs were complicated, but sometimes using `runtests.py` (which is also on the way out I think..) contributed to hangs b/c of multiprocessing import orders. So, try to use `pytest` directly instead to see if it helps

* I suspect these changes are "just fine" to apply even if we're going to switch to 3.9 minimum sooner than later