### PR TITLE
ENH: `multivariate_normal_frozen`: restore `cov` attribute (#17904)

### DIFF
--- a/scipy/stats/_multivariate.py
+++ b/scipy/stats/_multivariate.py
@@ -839,6 +839,10 @@ class multivariate_normal_frozen(multi_rv_frozen):
         self.abseps = abseps
         self.releps = releps
 
+    @property
+    def cov(self):
+        return self.cov_object.covariance
+
     def logpdf(self, x):
         x = self._dist._process_quantiles(x, self.dim)
         out = self._dist._logpdf(x, self.mean, self.cov_object)

--- a/scipy/stats/tests/test_multivariate.py
+++ b/scipy/stats/tests/test_multivariate.py
@@ -513,6 +513,20 @@ class TestMultivariateNormal:
         assert_allclose(norm_frozen.cdf(x), multivariate_normal.cdf(x, mean, cov))
         assert_allclose(norm_frozen.logcdf(x),
                         multivariate_normal.logcdf(x, mean, cov))
+    
+    @pytest.mark.parametrize(
+        'covariance',
+        [
+            np.eye(2),
+            Covariance.from_diagonal([1, 1]),
+        ]
+    )
+    def test_frozen_multivariate_normal_exposes_attributes(self, covariance):
+        mean = np.ones((2,))
+        cov_should_be = np.eye(2)
+        norm_frozen = multivariate_normal(mean, covariance)
+        assert np.allclose(norm_frozen.mean, mean)
+        assert np.allclose(norm_frozen.cov, cov_should_be)
 
     def test_pseudodet_pinv(self):
         # Make sure that pseudo-inverse and pseudo-det agree on cutoff


### PR DESCRIPTION
#### What does this implement/fix?
Restores the ability to access the `cov` attribute of a frozen multivariate normal distribution, which was inadvertently removed in 1.10.0. Whether this attribute is "public" or not is questionable, as it is only mentioned in an _example_ of the `multivariate_normal_frozen` documentation, which Sphinx does not render and refguide checks don't cover, but there is no harm in restoring the behavior of code that may have relied on this attribute for the past 20 years.