### PR TITLE
DEMO: testing torch device MPS with cirrus CI

### DIFF
--- a/.cirrus.star
+++ b/.cirrus.star
@@ -17,7 +17,7 @@ def main(ctx):
     # - commit message containing [wheel build]
     ######################################################################
 
-    if env.get("CIRRUS_REPO_FULL_NAME") != "scipy/scipy":
+    if env.get("CIRRUS_REPO_FULL_NAME") != "tylerjereddy/scipy":
         return []
 
     if env.get("CIRRUS_CRON", "") == "nightly":

--- a/ci/cirrus_general_ci.yml
+++ b/ci/cirrus_general_ci.yml
@@ -143,4 +143,5 @@ macos_arm64_test_task:
     python -m pip install click rich_click doit pydevtool
     python -m pip install pytest pooch
     export DYLD_LIBRARY_PATH=/usr/local/gfortran/lib:/opt/arm64-builds/lib
-    python dev.py test
+    # spot check array API torch MPS device compliance
+    SCIPY_TORCH_DEVICE=mps python dev.py test -b numpy -b pytorch -s cluster

--- a/ci/cirrus_general_ci.yml
+++ b/ci/cirrus_general_ci.yml
@@ -143,6 +143,6 @@ macos_arm64_test_task:
     python -m pip install click rich_click doit pydevtool
     python -m pip install pytest pooch
     export DYLD_LIBRARY_PATH=/usr/local/gfortran/lib:/opt/arm64-builds/lib
-    python -m pip install torch
+    python -m pip install torch array-api-compat
     # spot check array API torch MPS device compliance
     SCIPY_TORCH_DEVICE=mps python dev.py test -b numpy -b pytorch -s cluster

--- a/ci/cirrus_general_ci.yml
+++ b/ci/cirrus_general_ci.yml
@@ -143,5 +143,6 @@ macos_arm64_test_task:
     python -m pip install click rich_click doit pydevtool
     python -m pip install pytest pooch
     export DYLD_LIBRARY_PATH=/usr/local/gfortran/lib:/opt/arm64-builds/lib
+    python -m pip install torch
     # spot check array API torch MPS device compliance
     SCIPY_TORCH_DEVICE=mps python dev.py test -b numpy -b pytorch -s cluster

--- a/scipy/conftest.py
+++ b/scipy/conftest.py
@@ -132,6 +132,10 @@ if SCIPY_ARRAY_API:
 
 array_api_compatible = pytest.mark.parametrize("xp", array_api_backends)
 
+if "pytorch" in array_api_available_backends:
+    torch_device_setting = os.environ.get("SCIPY_TORCH_DEVICE", "cpu")
+    torch.set_default_device(torch_device_setting)
+
 skip_if_array_api = pytest.mark.skipif(
     SCIPY_ARRAY_API,
     reason="do not run with Array API on",


### PR DESCRIPTION
Quick demo to show that we can test on native ARM mac metal performance shaders (MPS GPU) on cirrus CI so we have at least one array API "device" other than host tested in CI.